### PR TITLE
No deploy CRDs

### DIFF
--- a/helm/prometheus-operator-app-chart/values.yaml
+++ b/helm/prometheus-operator-app-chart/values.yaml
@@ -916,7 +916,7 @@ prometheusOperator:
 
   ## Deploy CRDs used by Prometheus Operator.
   ##
-  createCustomResource: true
+  createCustomResource: false
 
   ## Customize CRDs API Group
   crdApiGroup: monitoring.coreos.com


### PR DESCRIPTION
By the nature of the Prometheus Operator chart deploy the CRDs is error-prone. The best way to solve the problem is by pre-installing the CRDs as they advise in README. Based in my experience with IStio I will try to help to fix the issue with a helm sub chart in following PRs