### PR TITLE
Update architect-orb dependency to 0.1.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@0.1.1
+  architect: giantswarm/architect@0.1.2
 
 workflows:
   package-and-push-chart-on-tag:


### PR DESCRIPTION
Purpose of this update is to benefit from the fix for package-and-push command fix, to index+merge only new package and not re-index whole app catalog repository.