### PR TITLE
Assign pre-install hook to CRDs  to support helm 3

### DIFF
--- a/helm/prometheus-operator-app/crds/crd-alertmanager.yaml
+++ b/helm/prometheus-operator-app/crds/crd-alertmanager.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.4
-    helm.sh/hook: crd-install
+    helm.sh/hook: pre-install
   creationTimestamp: null
   name: alertmanagers.monitoring.coreos.com
 spec:

--- a/helm/prometheus-operator-app/crds/crd-podmonitor.yaml
+++ b/helm/prometheus-operator-app/crds/crd-podmonitor.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.4
-    helm.sh/hook: crd-install
+    helm.sh/hook: pre-install
   creationTimestamp: null
   name: podmonitors.monitoring.coreos.com
 spec:

--- a/helm/prometheus-operator-app/crds/crd-prometheus.yaml
+++ b/helm/prometheus-operator-app/crds/crd-prometheus.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.4
-    helm.sh/hook: crd-install
+    helm.sh/hook: pre-install
   creationTimestamp: null
   name: prometheuses.monitoring.coreos.com
 spec:

--- a/helm/prometheus-operator-app/crds/crd-prometheusrules.yaml
+++ b/helm/prometheus-operator-app/crds/crd-prometheusrules.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.4
-    helm.sh/hook: crd-install
+    helm.sh/hook: pre-install
   creationTimestamp: null
   name: prometheusrules.monitoring.coreos.com
 spec:

--- a/helm/prometheus-operator-app/crds/crd-servicemonitor.yaml
+++ b/helm/prometheus-operator-app/crds/crd-servicemonitor.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.4
-    helm.sh/hook: crd-install
+    helm.sh/hook: pre-install
   creationTimestamp: null
   name: servicemonitors.monitoring.coreos.com
 spec:

--- a/helm/prometheus-operator-app/crds/crd-thanosrulers.yaml
+++ b/helm/prometheus-operator-app/crds/crd-thanosrulers.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.4
-    helm.sh/hook: crd-install
+    helm.sh/hook: pre-install
   creationTimestamp: null
   name: thanosrulers.monitoring.coreos.com
 spec:


### PR DESCRIPTION
Toward giantswarm/giantswarm#11075

Changes are to use the same CRD for Helm3.