### PR TITLE
Reintroduce crd-install as hook

### DIFF
--- a/helm/prometheus-operator-app/crds/crd-alertmanager.yaml
+++ b/helm/prometheus-operator-app/crds/crd-alertmanager.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.4
-    helm.sh/hook: pre-install
+    helm.sh/hook: crd-install
   creationTimestamp: null
   name: alertmanagers.monitoring.coreos.com
 spec:

--- a/helm/prometheus-operator-app/crds/crd-podmonitor.yaml
+++ b/helm/prometheus-operator-app/crds/crd-podmonitor.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.4
-    helm.sh/hook: pre-install
+    helm.sh/hook: crd-install
   creationTimestamp: null
   name: podmonitors.monitoring.coreos.com
 spec:

--- a/helm/prometheus-operator-app/crds/crd-prometheus.yaml
+++ b/helm/prometheus-operator-app/crds/crd-prometheus.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.4
-    helm.sh/hook: pre-install
+    helm.sh/hook: crd-install
   creationTimestamp: null
   name: prometheuses.monitoring.coreos.com
 spec:

--- a/helm/prometheus-operator-app/crds/crd-prometheusrules.yaml
+++ b/helm/prometheus-operator-app/crds/crd-prometheusrules.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.4
-    helm.sh/hook: pre-install
+    helm.sh/hook: crd-install
   creationTimestamp: null
   name: prometheusrules.monitoring.coreos.com
 spec:

--- a/helm/prometheus-operator-app/crds/crd-servicemonitor.yaml
+++ b/helm/prometheus-operator-app/crds/crd-servicemonitor.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.4
-    helm.sh/hook: pre-install
+    helm.sh/hook: crd-install
   creationTimestamp: null
   name: servicemonitors.monitoring.coreos.com
 spec:

--- a/helm/prometheus-operator-app/crds/crd-thanosrulers.yaml
+++ b/helm/prometheus-operator-app/crds/crd-thanosrulers.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.4
-    helm.sh/hook: pre-install
+    helm.sh/hook: crd-install
   creationTimestamp: null
   name: thanosrulers.monitoring.coreos.com
 spec:


### PR DESCRIPTION
To mitigate an error below from TC, we need to introduce the `crd-install` hook in CRD. 
This is because the promethes-operator-app is using CRs initially right after a release setup. 
```
[tiller] 2020/06/15 17:02:51 performing install for prometheus-operator-app
[tiller] 2020/06/15 17:02:51 executing 15 crd-install hooks for prometheus-operator-app
[tiller] 2020/06/15 17:02:51 hooks complete for crd-install prometheus-operator-app
[tiller] 2020/06/15 17:02:52 failed install perform step: validation failed: [unable to recognize "": no matches for kind "Alertmanager" in version "monitoring.coreos.com/v1", unable to recognize "": no matches for kind "Prometheus" in version "monitoring.coreos.com/v1", unable to recognize "": no matches for kind "PrometheusRule" in version "monitoring.coreos.com/v1", unable to recognize "": no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"]
```

slack thread: https://gigantic.slack.com/archives/CR99LSZ1N/p1592237301098000