### PR TITLE
Add prometheus operator values schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+- Added values schema for validating default values
+
 ## [0.4.0] - 2020-10-15
 
 ### Added

--- a/helm/prometheus-operator-app/Chart.yaml
+++ b/helm/prometheus-operator-app/Chart.yaml
@@ -34,3 +34,4 @@ annotations:
       url: https://github.com/prometheus-community/helm-charts
     - name: Upstream Project
       url: https://github.com/prometheus-operator/kube-prometheus
+  application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/prometheus-operator-app/v[[ .Version ]]/helm/prometheus-operator-app/values.schema.json

--- a/helm/prometheus-operator-app/values.schema.json
+++ b/helm/prometheus-operator-app/values.schema.json
@@ -1,0 +1,1927 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "additionalPrometheusRulesMap": {
+            "type": "object"
+        },
+        "alertmanager": {
+            "type": "object",
+            "properties": {
+                "alertmanagerSpec": {
+                    "type": "object",
+                    "properties": {
+                        "additionalPeers": {
+                            "type": "array"
+                        },
+                        "affinity": {
+                            "type": "object"
+                        },
+                        "clusterAdvertiseAddress": {
+                            "type": "boolean"
+                        },
+                        "configMaps": {
+                            "type": "array"
+                        },
+                        "containers": {
+                            "type": "array"
+                        },
+                        "externalUrl": {
+                            "type": "null"
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "sha": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "listenLocal": {
+                            "type": "boolean"
+                        },
+                        "logFormat": {
+                            "type": "string"
+                        },
+                        "logLevel": {
+                            "type": "string"
+                        },
+                        "nodeSelector": {
+                            "type": "object"
+                        },
+                        "paused": {
+                            "type": "boolean"
+                        },
+                        "podAntiAffinity": {
+                            "type": "string"
+                        },
+                        "podAntiAffinityTopologyKey": {
+                            "type": "string"
+                        },
+                        "podMetadata": {
+                            "type": "object"
+                        },
+                        "portName": {
+                            "type": "string"
+                        },
+                        "priorityClassName": {
+                            "type": "string"
+                        },
+                        "replicas": {
+                            "type": "integer"
+                        },
+                        "resources": {
+                            "type": "object"
+                        },
+                        "retention": {
+                            "type": "string"
+                        },
+                        "routePrefix": {
+                            "type": "string"
+                        },
+                        "secrets": {
+                            "type": "array"
+                        },
+                        "securityContext": {
+                            "type": "object",
+                            "properties": {
+                                "fsGroup": {
+                                    "type": "integer"
+                                },
+                                "runAsGroup": {
+                                    "type": "integer"
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean"
+                                },
+                                "runAsUser": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "storage": {
+                            "type": "object"
+                        },
+                        "tolerations": {
+                            "type": "array"
+                        },
+                        "useExistingSecret": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "apiVersion": {
+                    "type": "string"
+                },
+                "config": {
+                    "type": "object",
+                    "properties": {
+                        "global": {
+                            "type": "object",
+                            "properties": {
+                                "resolve_timeout": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "receivers": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "route": {
+                            "type": "object",
+                            "properties": {
+                                "group_by": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "group_interval": {
+                                    "type": "string"
+                                },
+                                "group_wait": {
+                                    "type": "string"
+                                },
+                                "receiver": {
+                                    "type": "string"
+                                },
+                                "repeat_interval": {
+                                    "type": "string"
+                                },
+                                "routes": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "match": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "alertname": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            },
+                                            "receiver": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "hosts": {
+                            "type": "array"
+                        },
+                        "labels": {
+                            "type": "object"
+                        },
+                        "paths": {
+                            "type": "array"
+                        },
+                        "tls": {
+                            "type": "array"
+                        }
+                    }
+                },
+                "ingressPerReplica": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "hostDomain": {
+                            "type": "string"
+                        },
+                        "hostPrefix": {
+                            "type": "string"
+                        },
+                        "labels": {
+                            "type": "object"
+                        },
+                        "paths": {
+                            "type": "array"
+                        },
+                        "tlsSecretName": {
+                            "type": "string"
+                        },
+                        "tlsSecretPerReplica": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "prefix": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "podDisruptionBudget": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "maxUnavailable": {
+                            "type": "string"
+                        },
+                        "minAvailable": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "secret": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "clusterIP": {
+                            "type": "string"
+                        },
+                        "externalIPs": {
+                            "type": "array"
+                        },
+                        "labels": {
+                            "type": "object"
+                        },
+                        "loadBalancerIP": {
+                            "type": "string"
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array"
+                        },
+                        "nodePort": {
+                            "type": "integer"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "targetPort": {
+                            "type": "integer"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "bearerTokenFile": {
+                            "type": "null"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "metricRelabelings": {
+                            "type": "array"
+                        },
+                        "relabelings": {
+                            "type": "array"
+                        },
+                        "scheme": {
+                            "type": "string"
+                        },
+                        "selfMonitor": {
+                            "type": "boolean"
+                        },
+                        "tlsConfig": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "servicePerReplica": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array"
+                        },
+                        "nodePort": {
+                            "type": "integer"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "targetPort": {
+                            "type": "integer"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "templateFiles": {
+                    "type": "object"
+                },
+                "tplConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "commonLabels": {
+            "type": "object"
+        },
+        "coreDns": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "port": {
+                            "type": "integer"
+                        },
+                        "targetPort": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "interval": {
+                            "type": "string"
+                        },
+                        "metricRelabelings": {
+                            "type": "array"
+                        },
+                        "relabelings": {
+                            "type": "array"
+                        }
+                    }
+                }
+            }
+        },
+        "defaultRules": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "appNamespacesTarget": {
+                    "type": "string"
+                },
+                "create": {
+                    "type": "boolean"
+                },
+                "labels": {
+                    "type": "object"
+                },
+                "rules": {
+                    "type": "object",
+                    "properties": {
+                        "alertmanager": {
+                            "type": "boolean"
+                        },
+                        "etcd": {
+                            "type": "boolean"
+                        },
+                        "general": {
+                            "type": "boolean"
+                        },
+                        "k8s": {
+                            "type": "boolean"
+                        },
+                        "kubeApiserver": {
+                            "type": "boolean"
+                        },
+                        "kubeApiserverAvailability": {
+                            "type": "boolean"
+                        },
+                        "kubeApiserverError": {
+                            "type": "boolean"
+                        },
+                        "kubeApiserverSlos": {
+                            "type": "boolean"
+                        },
+                        "kubePrometheusGeneral": {
+                            "type": "boolean"
+                        },
+                        "kubePrometheusNodeAlerting": {
+                            "type": "boolean"
+                        },
+                        "kubePrometheusNodeRecording": {
+                            "type": "boolean"
+                        },
+                        "kubeScheduler": {
+                            "type": "boolean"
+                        },
+                        "kubeStateMetrics": {
+                            "type": "boolean"
+                        },
+                        "kubelet": {
+                            "type": "boolean"
+                        },
+                        "kubernetesAbsent": {
+                            "type": "boolean"
+                        },
+                        "kubernetesApps": {
+                            "type": "boolean"
+                        },
+                        "kubernetesResources": {
+                            "type": "boolean"
+                        },
+                        "kubernetesStorage": {
+                            "type": "boolean"
+                        },
+                        "kubernetesSystem": {
+                            "type": "boolean"
+                        },
+                        "network": {
+                            "type": "boolean"
+                        },
+                        "node": {
+                            "type": "boolean"
+                        },
+                        "prometheus": {
+                            "type": "boolean"
+                        },
+                        "prometheusOperator": {
+                            "type": "boolean"
+                        },
+                        "time": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "runbookUrl": {
+                    "type": "string"
+                }
+            }
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "global": {
+            "type": "object",
+            "properties": {
+                "imagePullSecrets": {
+                    "type": "array"
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "pspAnnotations": {
+                            "type": "object"
+                        },
+                        "pspEnabled": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
+        "grafana": {
+            "type": "object",
+            "properties": {
+                "additionalDataSources": {
+                    "type": "array"
+                },
+                "adminPassword": {
+                    "type": "string"
+                },
+                "defaultDashboardsEnabled": {
+                    "type": "boolean"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "extraConfigmapMounts": {
+                    "type": "array"
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "hosts": {
+                            "type": "array"
+                        },
+                        "labels": {
+                            "type": "object"
+                        },
+                        "path": {
+                            "type": "string"
+                        },
+                        "tls": {
+                            "type": "array"
+                        }
+                    }
+                },
+                "namespaceOverride": {
+                    "type": "string"
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "pspUseAppArmor": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "portName": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "interval": {
+                            "type": "string"
+                        },
+                        "metricRelabelings": {
+                            "type": "array"
+                        },
+                        "relabelings": {
+                            "type": "array"
+                        },
+                        "selfMonitor": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "sidecar": {
+                    "type": "object",
+                    "properties": {
+                        "dashboards": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object"
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "label": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "datasources": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object"
+                                },
+                                "createPrometheusReplicasDatasources": {
+                                    "type": "boolean"
+                                },
+                                "defaultDatasourceEnabled": {
+                                    "type": "boolean"
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "label": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string"
+                }
+            }
+        },
+        "kube-state-metrics": {
+            "type": "object",
+            "properties": {
+                "namespaceOverride": {
+                    "type": "string"
+                },
+                "podSecurityPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
+        "kubeApiServer": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "relabelings": {
+                    "type": "array"
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "interval": {
+                            "type": "string"
+                        },
+                        "jobLabel": {
+                            "type": "string"
+                        },
+                        "metricRelabelings": {
+                            "type": "array"
+                        },
+                        "selector": {
+                            "type": "object",
+                            "properties": {
+                                "matchLabels": {
+                                    "type": "object",
+                                    "properties": {
+                                        "component": {
+                                            "type": "string"
+                                        },
+                                        "provider": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "tlsConfig": {
+                    "type": "object",
+                    "properties": {
+                        "insecureSkipVerify": {
+                            "type": "boolean"
+                        },
+                        "serverName": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "kubeControllerManager": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "endpoints": {
+                    "type": "array"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "port": {
+                            "type": "integer"
+                        },
+                        "targetPort": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "https": {
+                            "type": "boolean"
+                        },
+                        "insecureSkipVerify": {
+                            "type": "null"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "metricRelabelings": {
+                            "type": "array"
+                        },
+                        "relabelings": {
+                            "type": "array"
+                        },
+                        "serverName": {
+                            "type": "null"
+                        }
+                    }
+                }
+            }
+        },
+        "kubeDns": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "dnsmasq": {
+                            "type": "object",
+                            "properties": {
+                                "port": {
+                                    "type": "integer"
+                                },
+                                "targetPort": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "skydns": {
+                            "type": "object",
+                            "properties": {
+                                "port": {
+                                    "type": "integer"
+                                },
+                                "targetPort": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "dnsmasqMetricRelabelings": {
+                            "type": "array"
+                        },
+                        "dnsmasqRelabelings": {
+                            "type": "array"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "metricRelabelings": {
+                            "type": "array"
+                        },
+                        "relabelings": {
+                            "type": "array"
+                        }
+                    }
+                }
+            }
+        },
+        "kubeEtcd": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "endpoints": {
+                    "type": "array"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "port": {
+                            "type": "integer"
+                        },
+                        "targetPort": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "caFile": {
+                            "type": "string"
+                        },
+                        "certFile": {
+                            "type": "string"
+                        },
+                        "insecureSkipVerify": {
+                            "type": "boolean"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "keyFile": {
+                            "type": "string"
+                        },
+                        "metricRelabelings": {
+                            "type": "array"
+                        },
+                        "relabelings": {
+                            "type": "array"
+                        },
+                        "scheme": {
+                            "type": "string"
+                        },
+                        "serverName": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "kubeProxy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "endpoints": {
+                    "type": "array"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "port": {
+                            "type": "integer"
+                        },
+                        "targetPort": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "https": {
+                            "type": "boolean"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "metricRelabelings": {
+                            "type": "array"
+                        },
+                        "relabelings": {
+                            "type": "array"
+                        }
+                    }
+                }
+            }
+        },
+        "kubeScheduler": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "endpoints": {
+                    "type": "array"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "port": {
+                            "type": "integer"
+                        },
+                        "targetPort": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "https": {
+                            "type": "boolean"
+                        },
+                        "insecureSkipVerify": {
+                            "type": "null"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "metricRelabelings": {
+                            "type": "array"
+                        },
+                        "relabelings": {
+                            "type": "array"
+                        },
+                        "serverName": {
+                            "type": "null"
+                        }
+                    }
+                }
+            }
+        },
+        "kubeStateMetrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "interval": {
+                            "type": "string"
+                        },
+                        "metricRelabelings": {
+                            "type": "array"
+                        },
+                        "relabelings": {
+                            "type": "array"
+                        }
+                    }
+                }
+            }
+        },
+        "kubeTargetVersionOverride": {
+            "type": "string"
+        },
+        "kubelet": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "cAdvisor": {
+                            "type": "boolean"
+                        },
+                        "cAdvisorMetricRelabelings": {
+                            "type": "array"
+                        },
+                        "cAdvisorRelabelings": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "sourceLabels": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "targetLabel": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "https": {
+                            "type": "boolean"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "metricRelabelings": {
+                            "type": "array"
+                        },
+                        "probes": {
+                            "type": "boolean"
+                        },
+                        "probesMetricRelabelings": {
+                            "type": "array"
+                        },
+                        "probesRelabelings": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "sourceLabels": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "targetLabel": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "sourceLabels": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "targetLabel": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "resource": {
+                            "type": "boolean"
+                        },
+                        "resourcePath": {
+                            "type": "string"
+                        },
+                        "resourceRelabelings": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "sourceLabels": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "targetLabel": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "nameOverride": {
+            "type": "string"
+        },
+        "namespaceOverride": {
+            "type": "string"
+        },
+        "nodeExporter": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "jobLabel": {
+                    "type": "string"
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "interval": {
+                            "type": "string"
+                        },
+                        "metricRelabelings": {
+                            "type": "array"
+                        },
+                        "relabelings": {
+                            "type": "array"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "prometheus": {
+            "type": "object",
+            "properties": {
+                "additionalPodMonitors": {
+                    "type": "array"
+                },
+                "additionalServiceMonitors": {
+                    "type": "array"
+                },
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "hosts": {
+                            "type": "array"
+                        },
+                        "labels": {
+                            "type": "object"
+                        },
+                        "paths": {
+                            "type": "array"
+                        },
+                        "tls": {
+                            "type": "array"
+                        }
+                    }
+                },
+                "ingressPerReplica": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "hostDomain": {
+                            "type": "string"
+                        },
+                        "hostPrefix": {
+                            "type": "string"
+                        },
+                        "labels": {
+                            "type": "object"
+                        },
+                        "paths": {
+                            "type": "array"
+                        },
+                        "tlsSecretName": {
+                            "type": "string"
+                        },
+                        "tlsSecretPerReplica": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "prefix": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "podDisruptionBudget": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "maxUnavailable": {
+                            "type": "string"
+                        },
+                        "minAvailable": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "podSecurityPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "allowedCapabilities": {
+                            "type": "array"
+                        }
+                    }
+                },
+                "prometheusSpec": {
+                    "type": "object",
+                    "properties": {
+                        "additionalAlertManagerConfigs": {
+                            "type": "array"
+                        },
+                        "additionalAlertRelabelConfigs": {
+                            "type": "array"
+                        },
+                        "additionalPrometheusSecretsAnnotations": {
+                            "type": "object"
+                        },
+                        "additionalScrapeConfigs": {
+                            "type": "array"
+                        },
+                        "additionalScrapeConfigsSecret": {
+                            "type": "object"
+                        },
+                        "affinity": {
+                            "type": "object"
+                        },
+                        "alertingEndpoints": {
+                            "type": "array"
+                        },
+                        "apiserverConfig": {
+                            "type": "object"
+                        },
+                        "configMaps": {
+                            "type": "array"
+                        },
+                        "containers": {
+                            "type": "array"
+                        },
+                        "disableCompaction": {
+                            "type": "boolean"
+                        },
+                        "enableAdminAPI": {
+                            "type": "boolean"
+                        },
+                        "evaluationInterval": {
+                            "type": "string"
+                        },
+                        "externalLabels": {
+                            "type": "object"
+                        },
+                        "externalUrl": {
+                            "type": "string"
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "sha": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "initContainers": {
+                            "type": "array"
+                        },
+                        "listenLocal": {
+                            "type": "boolean"
+                        },
+                        "logFormat": {
+                            "type": "string"
+                        },
+                        "logLevel": {
+                            "type": "string"
+                        },
+                        "nodeSelector": {
+                            "type": "object"
+                        },
+                        "paused": {
+                            "type": "boolean"
+                        },
+                        "podAntiAffinity": {
+                            "type": "string"
+                        },
+                        "podAntiAffinityTopologyKey": {
+                            "type": "string"
+                        },
+                        "podMetadata": {
+                            "type": "object"
+                        },
+                        "podMonitorNamespaceSelector": {
+                            "type": "object"
+                        },
+                        "podMonitorSelector": {
+                            "type": "object"
+                        },
+                        "podMonitorSelectorNilUsesHelmValues": {
+                            "type": "boolean"
+                        },
+                        "portName": {
+                            "type": "string"
+                        },
+                        "priorityClassName": {
+                            "type": "string"
+                        },
+                        "prometheusExternalLabelName": {
+                            "type": "string"
+                        },
+                        "prometheusExternalLabelNameClear": {
+                            "type": "boolean"
+                        },
+                        "query": {
+                            "type": "object"
+                        },
+                        "remoteRead": {
+                            "type": "array"
+                        },
+                        "remoteWrite": {
+                            "type": "array"
+                        },
+                        "remoteWriteDashboards": {
+                            "type": "boolean"
+                        },
+                        "replicaExternalLabelName": {
+                            "type": "string"
+                        },
+                        "replicaExternalLabelNameClear": {
+                            "type": "boolean"
+                        },
+                        "replicas": {
+                            "type": "integer"
+                        },
+                        "resources": {
+                            "type": "object"
+                        },
+                        "retention": {
+                            "type": "string"
+                        },
+                        "retentionSize": {
+                            "type": "string"
+                        },
+                        "routePrefix": {
+                            "type": "string"
+                        },
+                        "ruleNamespaceSelector": {
+                            "type": "object"
+                        },
+                        "ruleSelector": {
+                            "type": "object"
+                        },
+                        "ruleSelectorNilUsesHelmValues": {
+                            "type": "boolean"
+                        },
+                        "scrapeInterval": {
+                            "type": "string"
+                        },
+                        "secrets": {
+                            "type": "array"
+                        },
+                        "securityContext": {
+                            "type": "object",
+                            "properties": {
+                                "fsGroup": {
+                                    "type": "integer"
+                                },
+                                "runAsGroup": {
+                                    "type": "integer"
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean"
+                                },
+                                "runAsUser": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "serviceMonitorNamespaceSelector": {
+                            "type": "object"
+                        },
+                        "serviceMonitorSelector": {
+                            "type": "object"
+                        },
+                        "serviceMonitorSelectorNilUsesHelmValues": {
+                            "type": "boolean"
+                        },
+                        "storageSpec": {
+                            "type": "object"
+                        },
+                        "thanos": {
+                            "type": "object"
+                        },
+                        "tolerations": {
+                            "type": "array"
+                        },
+                        "volumeMounts": {
+                            "type": "array"
+                        },
+                        "volumes": {
+                            "type": "array"
+                        },
+                        "walCompression": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "clusterIP": {
+                            "type": "string"
+                        },
+                        "externalIPs": {
+                            "type": "array"
+                        },
+                        "labels": {
+                            "type": "object"
+                        },
+                        "loadBalancerIP": {
+                            "type": "string"
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array"
+                        },
+                        "nodePort": {
+                            "type": "integer"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "sessionAffinity": {
+                            "type": "string"
+                        },
+                        "targetPort": {
+                            "type": "integer"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "bearerTokenFile": {
+                            "type": "null"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "metricRelabelings": {
+                            "type": "array"
+                        },
+                        "relabelings": {
+                            "type": "array"
+                        },
+                        "scheme": {
+                            "type": "string"
+                        },
+                        "selfMonitor": {
+                            "type": "boolean"
+                        },
+                        "tlsConfig": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "servicePerReplica": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array"
+                        },
+                        "nodePort": {
+                            "type": "integer"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "targetPort": {
+                            "type": "integer"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "thanosIngress": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "hosts": {
+                            "type": "array"
+                        },
+                        "labels": {
+                            "type": "object"
+                        },
+                        "paths": {
+                            "type": "array"
+                        },
+                        "servicePort": {
+                            "type": "integer"
+                        },
+                        "tls": {
+                            "type": "array"
+                        }
+                    }
+                }
+            }
+        },
+        "prometheus-node-exporter": {
+            "type": "object",
+            "properties": {
+                "extraArgs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "namespaceOverride": {
+                    "type": "string"
+                },
+                "podLabels": {
+                    "type": "object",
+                    "properties": {
+                        "jobLabel": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "prometheusOperator": {
+            "type": "object",
+            "properties": {
+                "admissionWebhooks": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "failurePolicy": {
+                            "type": "string"
+                        },
+                        "patch": {
+                            "type": "object",
+                            "properties": {
+                                "affinity": {
+                                    "type": "object"
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "image": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "pullPolicy": {
+                                            "type": "string"
+                                        },
+                                        "sha": {
+                                            "type": "string"
+                                        },
+                                        "tag": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "nodeSelector": {
+                                    "type": "object"
+                                },
+                                "podAnnotations": {
+                                    "type": "object"
+                                },
+                                "priorityClassName": {
+                                    "type": "string"
+                                },
+                                "resources": {
+                                    "type": "object"
+                                },
+                                "tolerations": {
+                                    "type": "array"
+                                }
+                            }
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object"
+                },
+                "alertmanagerInstanceNamespaces": {
+                    "type": "array"
+                },
+                "cleanupCustomResource": {
+                    "type": "boolean"
+                },
+                "configReloaderCpu": {
+                    "type": "string"
+                },
+                "configReloaderMemory": {
+                    "type": "string"
+                },
+                "configmapReloadImage": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "sha": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "createCustomResource": {
+                    "type": "boolean"
+                },
+                "denyNamespaces": {
+                    "type": "array"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "hostNetwork": {
+                    "type": "boolean"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "sha": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "kubectlImage": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "sha": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "kubeletService": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "manageCrds": {
+                    "type": "boolean"
+                },
+                "namespaces": {
+                    "type": "object"
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "podLabels": {
+                    "type": "object"
+                },
+                "prometheusConfigReloaderImage": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "sha": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "prometheusInstanceNamespaces": {
+                    "type": "array"
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "secretFieldSelector": {
+                    "type": "string"
+                },
+                "securityContext": {
+                    "type": "object",
+                    "properties": {
+                        "fsGroup": {
+                            "type": "integer"
+                        },
+                        "runAsGroup": {
+                            "type": "integer"
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean"
+                        },
+                        "runAsUser": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "additionalPorts": {
+                            "type": "array"
+                        },
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "clusterIP": {
+                            "type": "string"
+                        },
+                        "externalIPs": {
+                            "type": "array"
+                        },
+                        "labels": {
+                            "type": "object"
+                        },
+                        "loadBalancerIP": {
+                            "type": "string"
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array"
+                        },
+                        "nodePort": {
+                            "type": "integer"
+                        },
+                        "nodePortTls": {
+                            "type": "integer"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "interval": {
+                            "type": "string"
+                        },
+                        "metricRelabelings": {
+                            "type": "array"
+                        },
+                        "relabelings": {
+                            "type": "array"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string"
+                        },
+                        "selfMonitor": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "thanosInstanceNamespaces": {
+                    "type": "array"
+                },
+                "tlsProxy": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "pullPolicy": {
+                                    "type": "string"
+                                },
+                                "sha": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "resources": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "tolerations": {
+                    "type": "array"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
@app-squad-prometheus will be automatically requested for review once
this PR has been submitted.
-->

Towards https://github.com/giantswarm/roadmap/issues/136 with @oponder 

This PR adds `values.schema.json` generated from the current values.yaml using https://github.com/karuppiah7890/helm-schema-gen

It is a good starting point and can be further refined by those that know more about the specifics of the values. (For example if we know that `provider` must be aws|azure|kvm, we can actually enforce that as well using the 'enum' property: https://json-schema.org/understanding-json-schema/reference/generic.html#enumerated-values)

Here's also some more general info: https://www.arthurkoziel.com/validate-helm-chart-values-with-json-schemas/

I tested in giantswarm namespace in gorilla and got no errors.

```
(⎈ |giantswarm-gorilla:default)➜  kubectl-gs git:(app-validate) ./kubectl-gs validate apps prometheus-operator-app-unique -n giantswarm -f=/Users/chiaracokieng/Documents/GitHub/prometheus-operator-app/helm/prometheus-operator-app/values.schema.json -o report

Validated 1 app across 1 namespace

giantswarm [1 app, 0 errors]
```

---

I used the currently in progress `kubectl-gs validate apps` command to help with the verifying current values : https://github.com/giantswarm/kubectl-gs/pull/196

Here's also a slack thread with a video about how that command works: https://gigantic.slack.com/archives/CRZN9GLJW/p1603092812002400