### PR TITLE
Change apply to create to avoid warning and change wording a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ Giant Swarm offers a Prometheus Operator Managed App which can be installed in
 tenant clusters. Here we define the Prometheus chart with its templates and
 default configuration.
 
-Be aware by default the CRDs are not installed in the cluster to avoid collisions with existing deployments of the chart. So in case it is the first time you install the chart add those manually like it is describe below or passing in the values the parameter `prometheusOperator.createCustomResource` equal to `true`.
+Be aware by default the CRDs are not installed in the cluster to avoid collisions with existing deployments of the chart. So in case it is the first time you install the chart set the parameter `prometheusOperator.createCustomResource` to `true` in you values configuration.
 
+Alternatively you can create the necessary `CustomResourceDefinition`s manually on your cluster:
 ```
-kubectl apply -f https://raw.githubusercontent.com/helm/charts/master/stable/prometheus-operator/crds/crd-alertmanager.yaml
-kubectl apply -f https://raw.githubusercontent.com/helm/charts/master/stable/prometheus-operator/crds/crd-podmonitor.yaml
-kubectl apply -f https://raw.githubusercontent.com/helm/charts/master/stable/prometheus-operator/crds/crd-prometheus.yaml
-kubectl apply -f https://raw.githubusercontent.com/helm/charts/master/stable/prometheus-operator/crds/crd-prometheusrules.yaml
-kubectl apply -f https://raw.githubusercontent.com/helm/charts/master/stable/prometheus-operator/crds/crd-servicemonitor.yaml
-kubectl apply -f https://raw.githubusercontent.com/helm/charts/master/stable/prometheus-operator/crds/crd-thanosrulers.yaml
+kubectl create -f https://raw.githubusercontent.com/helm/charts/master/stable/prometheus-operator/crds/crd-alertmanager.yaml
+kubectl create -f https://raw.githubusercontent.com/helm/charts/master/stable/prometheus-operator/crds/crd-podmonitor.yaml
+kubectl create -f https://raw.githubusercontent.com/helm/charts/master/stable/prometheus-operator/crds/crd-prometheus.yaml
+kubectl create -f https://raw.githubusercontent.com/helm/charts/master/stable/prometheus-operator/crds/crd-prometheusrules.yaml
+kubectl create -f https://raw.githubusercontent.com/helm/charts/master/stable/prometheus-operator/crds/crd-servicemonitor.yaml
+kubectl create -f https://raw.githubusercontent.com/helm/charts/master/stable/prometheus-operator/crds/crd-thanosrulers.yaml
 ```


### PR DESCRIPTION
With `kubectl apply` the following warning is shown:
```
Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
```

<!--
@app-squad-prometheus will be automatically requested for review once
this PR has been submitted.
-->
