### PR TITLE
Enable `ingressClass` and `pathType` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Enable `ingressClass` and `pathType` by default to ease installing on kubernetes >= 1.18.
+
 ## [0.7.2] - 2021-04-27
 
 - Internal release, do not use.

--- a/helm/prometheus-operator-app/values.schema.json
+++ b/helm/prometheus-operator-app/values.schema.json
@@ -230,8 +230,14 @@
                         "hosts": {
                             "type": "array"
                         },
+                        "ingressClassName": {
+                            "type": "string"
+                        },
                         "labels": {
                             "type": "object"
+                        },
+                        "pathType": {
+                            "type": "string"
                         },
                         "paths": {
                             "type": "array"
@@ -256,8 +262,14 @@
                         "hostPrefix": {
                             "type": "string"
                         },
+                        "ingressClassName": {
+                            "type": "string"
+                        },
                         "labels": {
                             "type": "object"
+                        },
+                        "pathType": {
+                            "type": "string"
                         },
                         "paths": {
                             "type": "array"
@@ -1290,8 +1302,14 @@
                         "hosts": {
                             "type": "array"
                         },
+                        "ingressClassName": {
+                            "type": "string"
+                        },
                         "labels": {
                             "type": "object"
+                        },
+                        "pathType": {
+                            "type": "string"
                         },
                         "paths": {
                             "type": "array"
@@ -1316,8 +1334,14 @@
                         "hostPrefix": {
                             "type": "string"
                         },
+                        "ingressClassName": {
+                            "type": "string"
+                        },
                         "labels": {
                             "type": "object"
+                        },
+                        "pathType": {
+                            "type": "string"
                         },
                         "paths": {
                             "type": "array"
@@ -1740,11 +1764,17 @@
                         "hosts": {
                             "type": "array"
                         },
+                        "ingressClassName": {
+                            "type": "string"
+                        },
                         "labels": {
                             "type": "object"
                         },
                         "nodePort": {
                             "type": "integer"
+                        },
+                        "pathType": {
+                            "type": "string"
                         },
                         "paths": {
                             "type": "array"

--- a/helm/prometheus-operator-app/values.yaml
+++ b/helm/prometheus-operator-app/values.yaml
@@ -212,7 +212,7 @@ alertmanager:
 
     # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
     # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
-    # ingressClassName: nginx
+    ingressClassName: nginx
 
     annotations: {}
 
@@ -230,7 +230,7 @@ alertmanager:
 
     ## For Kubernetes >= 1.18 you should specify the pathType (determines how Ingress paths should be matched)
     ## See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#better-path-matching-with-path-types
-    # pathType: ImplementationSpecific
+    pathType: ImplementationSpecific
 
     ## TLS configuration for Alertmanager Ingress
     ## Secret must be manually created in the namespace
@@ -253,7 +253,7 @@ alertmanager:
 
     # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
     # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
-    # ingressClassName: nginx
+    ingressClassName: nginx
 
     annotations: {}
     labels: {}
@@ -274,7 +274,7 @@ alertmanager:
 
     ## For Kubernetes >= 1.18 you should specify the pathType (determines how Ingress paths should be matched)
     ## See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#better-path-matching-with-path-types
-    # pathType: ImplementationSpecific
+    pathType: ImplementationSpecific
 
     ## Secret name containing the TLS certificate for alertmanager per replica ingress
     ## Secret must be manually created in the namespace
@@ -1695,7 +1695,7 @@ prometheus:
 
     # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
     # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
-    # ingressClassName: nginx
+    ingressClassName: nginx
 
     annotations: {}
     labels: {}
@@ -1718,7 +1718,7 @@ prometheus:
 
     ## For Kubernetes >= 1.18 you should specify the pathType (determines how Ingress paths should be matched)
     ## See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#better-path-matching-with-path-types
-    # pathType: ImplementationSpecific
+    pathType: ImplementationSpecific
 
     ## TLS configuration for Thanos Ingress
     ## Secret must be manually created in the namespace
@@ -1733,7 +1733,7 @@ prometheus:
 
     # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
     # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
-    # ingressClassName: nginx
+    ingressClassName: nginx
 
     annotations: {}
     labels: {}
@@ -1752,7 +1752,7 @@ prometheus:
 
     ## For Kubernetes >= 1.18 you should specify the pathType (determines how Ingress paths should be matched)
     ## See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#better-path-matching-with-path-types
-    # pathType: ImplementationSpecific
+    pathType: ImplementationSpecific
 
     ## TLS configuration for Prometheus Ingress
     ## Secret must be manually created in the namespace
@@ -1770,7 +1770,7 @@ prometheus:
 
     # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
     # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
-    # ingressClassName: nginx
+    ingressClassName: nginx
 
     annotations: {}
     labels: {}
@@ -1791,7 +1791,7 @@ prometheus:
 
     ## For Kubernetes >= 1.18 you should specify the pathType (determines how Ingress paths should be matched)
     ## See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#better-path-matching-with-path-types
-    # pathType: ImplementationSpecific
+    pathType: ImplementationSpecific
 
     ## Secret name containing the TLS certificate for Prometheus per replica ingress
     ## Secret must be manually created in the namespace


### PR DESCRIPTION
Enable `ingressClass` and `pathType` by default to ease installing on kubernetes >= 1.18.
