### PR TITLE
use standard tag for prometheus-operator-crd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ workflows:
           filters:
             # Trigger the job also on git tag.
             tags:
-              only: /^v.*-crd/
+              only: /^v.*/
 
       - architect/push-to-app-catalog:
           context: architect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Split CRDs into separate chart.
+
 ## [0.12.1] - 2021-12-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The default `values.yaml` contains setting `crds.install: true` to install and u
 
 ### release
 
-CRDs are held in the `prometheus-operator-crd` chart which is released separatly from this repository and uses tag with `v*-crd` format.
+CRDs are held in the `prometheus-operator-crd` chart which needs to be released before `prometheus-operator-app` dependencies can be upgraded.
 
 ## Good to know
 


### PR DESCRIPTION
Towards: giantswarm/giantswarm#20256

Well I'm not convinced about this now.

This means everytime we want to change CRDs we need 2 releases:

- 1 release to publish prometheus-operator-crd into the helm chart repo
- 1 release to update prometheus-operator-app dependency

Other solution is to split this into a separate repo, not a big fan also.