### PR TITLE
add crd dependency

### DIFF
--- a/helm/prometheus-operator-app/Chart.lock
+++ b/helm/prometheus-operator-app/Chart.lock
@@ -1,12 +1,15 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 4.1.1
+  version: 4.1.2
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 2.2.2
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.19.0
-digest: sha256:3437708289e2e35e8de7ac468e0d7fe2df43e2d459857b8855cc84cb18501832
-generated: "2021-12-10T14:28:39.401354003+01:00"
+  version: 6.19.4
+- name: prometheus-operator-crd
+  repository: https://giantswarm.github.io/giantswarm-catalog/
+  version: 0.12.2
+digest: sha256:89eeb89d913d32d2468e87fab69beb02cfb9354ae09a03d62e8b3ee10806a943
+generated: "2022-01-07T13:03:38.526833526+01:00"

--- a/helm/prometheus-operator-app/Chart.yaml
+++ b/helm/prometheus-operator-app/Chart.yaml
@@ -47,3 +47,7 @@ dependencies:
   version: "6.19.*"
   repository: https://grafana.github.io/helm-charts
   condition: grafana.enabled
+- name: prometheus-operator-crd
+  version: "0.12.*"
+  repository: https://giantswarm.github.io/giantswarm-catalog/
+  condition: crds.install


### PR DESCRIPTION
Towards: giantswarm/giantswarm#20256

Basically run `helm dependency update`

```
$ helm dependency update ./helm/prometheus-operator-app
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://giantswarm.github.io/giantswarm-catalog/" chart repository
...Successfully got an update from the "https://grafana.github.io/helm-charts" chart repository
...Successfully got an update from the "https://prometheus-community.github.io/helm-charts" chart repository
...Successfully got an update from the "https://prometheus-community.github.io/helm-charts" chart repository
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "cowboysysop" chart repository
...Successfully got an update from the "default" chart repository
...Unable to get an update from the "kubernetes-charts" chart repository (https://kubernetes-charts.storage.googleapis.com/):
        failed to fetch https://kubernetes-charts.storage.googleapis.com/index.yaml : 403 Forbidden
...Successfully got an update from the "fairwinds-stable" chart repository
...Successfully got an update from the "playground-test" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 4 charts
Downloading kube-state-metrics from repo https://prometheus-community.github.io/helm-charts
Downloading prometheus-node-exporter from repo https://prometheus-community.github.io/helm-charts
Downloading grafana from repo https://grafana.github.io/helm-charts
Downloading prometheus-operator-crd from repo https://giantswarm.github.io/giantswarm-catalog/
Deleting outdated charts
```

NOTE: I add to publish v0.12.2 git tag for this to work. I'll overwrite it with next release.