### PR TITLE
fix prometheus-operator-crd chart namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix CRD helm chart namespace
+
 ## [1.0.1] - 2022-01-20
 
 ### Changed

--- a/helm/prometheus-operator-app/templates/crd-install/crd-job.yaml
+++ b/helm/prometheus-operator-app/templates/crd-install/crd-job.yaml
@@ -38,6 +38,7 @@ spec:
           # in the pod's logs.
           exec 2>&1
 
-          kubectl api-resources --api-group=monitoring.coreos.com -oname|tr '\n' ' '|xargs kubectl patch --record=false -p '{"metadata":{"annotations":{"meta.helm.sh/release-name": "prometheus-operator-crd","meta.helm.sh/release-namespace": "prometheus-operator-crd"},"labels":{"app.kubernetes.io/managed-by": "Helm"}}}' crd
+          namespace=$(kubectl get chart --namespace=giantswarm prometheus-operator-crd --output=jsonpath="{.spec.namespace}")
+          kubectl api-resources --api-group=monitoring.coreos.com -oname|tr '\n' ' '|xargs kubectl patch --record=false -p '{"metadata":{"annotations":{"meta.helm.sh/release-name": "prometheus-operator-crd","meta.helm.sh/release-namespace": "'"${namespace}"'"},"labels":{"app.kubernetes.io/managed-by": "Helm"}}}' crd
       restartPolicy: Never
   backoffLimit: 4

--- a/helm/prometheus-operator-app/templates/crd-install/crd-rbac.yaml
+++ b/helm/prometheus-operator-app/templates/crd-install/crd-rbac.yaml
@@ -27,6 +27,12 @@ rules:
   - list
   - delete
 - apiGroups:
+  - application.giantswarm.io
+  resources:
+  - charts
+  verbs:
+  - get
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/20256

This solves an issue where CRDs are already installed but do not belong to any chart. We need to get the `prometheus-operator-crd` chart namespace in order to fake that it already belong to this chart.

Only requirements here is to make sure the `prometheus-operator-crd` is installed before this (if not the case, it also works).

To test:
- [x] Install from scratch works (install crd then app)
- [x] Upgrade on MC works (upgrade app)
- [x] Upgrade on WC works (install crd, then upgrade app and upgrade app then install crd)