### PR TITLE
Revert "remove kube-state-metrics fix (#157)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-### Fixed
-
-- Removed `kube-state-metrics` selector fix
-
 ## [1.0.1] - 2022-01-20
 
 ### Changed

--- a/helm/prometheus-operator-app/templates/_helpers.tpl
+++ b/helm/prometheus-operator-app/templates/_helpers.tpl
@@ -169,6 +169,10 @@ Use the prometheus-node-exporter namespace override for multi-namespace deployme
 {{- printf "%s-%s" ( include "kube-prometheus-stack.name" . ) "crd-install" | replace "+" "_" | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "kube-prometheus-stack.ksmFix" -}}
+{{- printf "%s-%s" ( include "kube-prometheus-stack.name" . ) "ksm-fix" | replace "+" "_" | trimSuffix "-" -}}
+{{- end -}}
+
 {{- define "kube-prometheus-stack.CRDInstallAnnotations" -}}
 "helm.sh/hook": "pre-upgrade"
 "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"

--- a/helm/prometheus-operator-app/templates/crd-install/kube-state-metrics-fix.yaml
+++ b/helm/prometheus-operator-app/templates/crd-install/kube-state-metrics-fix.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "kube-prometheus-stack.ksmFix" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-1"
+    {{- include "kube-prometheus-stack.CRDInstallAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "kube-prometheus-stack.ksmFix" . | quote }}
+    {{- include "kube-prometheus-stack.selectorLabels" . | nindent 4 }}
+    role: {{ include "kube-prometheus-stack.CRDInstallSelector" . | quote }}
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: {{ include "kube-prometheus-stack.ksmFix" . | quote }}
+        {{- include "kube-prometheus-stack.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "kube-prometheus-stack.crdInstall" . }}
+      securityContext:
+        runAsUser: 2000
+        runAsGroup: 2000
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: kubectl
+        image: "{{ .Values.image.registry }}/giantswarm/docker-kubectl:latest"
+        command:
+        - sh
+        - -c
+        - |
+          set -o errexit ; set -o xtrace ; set -o nounset
+
+          # piping stderr to stdout means kubectl's errors are surfaced
+          # in the pod's logs.
+          exec 2>&1
+
+          kubectl delete deployments.apps -l app.kubernetes.io/instance=prometheus-operator-app,app.kubernetes.io/name=kube-state-metrics --cascade=orphan
+      restartPolicy: Never
+  backoffLimit: 4


### PR DESCRIPTION
Towards: giantswarm/giantswarm#20256

This reverts commit a92dbf53ebed09fbb30d05c1925376c505120f34.

Keeping the fix because, no customer have upgraded yet and the chart will fail otherwise. Fix is harmless as it just delete a deployment.