### PR TITLE
add SLO for managed Prometheus

### DIFF
--- a/helm/prometheus-operator-app/templates/prometheus/prometheus.yaml
+++ b/helm/prometheus-operator-app/templates/prometheus/prometheus.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}-prometheus
+    giantswarm.io/monitoring_basic_sli: "true"
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.prometheus.annotations }}
   annotations:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/19310

Basically we do not need to manually add SLO requests, errors and targets we can just rely on already existing [managed app SLO setup](https://github.com/giantswarm/prometheus-rules/blob/5a589bea6b34cfdedad08450a937223a45886ca5/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml#L156-L225) by adding `giantswarm.io/monitoring_basic_sli: true` label
This PR replaces https://github.com/giantswarm/prometheus-rules/pull/249
