### PR TITLE
Support custom app name & namespace for prometheus-operator-crd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Fixed
 
-- Fix crd-install job to select crd chart by label.
+- Fix crd-install job to inject correct name and namespace for prometheus-operator-crd.
 
 ## [1.1.0] - 2022-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Fixed
 
-- Fix crd-install job to inject correct name and namespace for prometheus-operator-crd.
+- Support custom app name & namespace for prometheus-operator-crd.
 
 ## [1.1.0] - 2022-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix crd-install job to select crd chart by label.
+
 ## [1.1.0] - 2022-03-01
 
 ### Added

--- a/helm/prometheus-operator-app/templates/crd-install/crd-job.yaml
+++ b/helm/prometheus-operator-app/templates/crd-install/crd-job.yaml
@@ -38,7 +38,7 @@ spec:
           # in the pod's logs.
           exec 2>&1
 
-          namespace=$(kubectl get chart --namespace=giantswarm prometheus-operator-crd --output=jsonpath="{.spec.namespace}")
+          namespace=$(kubectl get chart --namespace=giantswarm -l app.kubernetes.io/name=prometheus-operator-crd --output=jsonpath="{.items[0].spec.namespace}")
           kubectl api-resources --api-group=monitoring.coreos.com -oname|tr '\n' ' '|xargs kubectl patch --record=false -p '{"metadata":{"annotations":{"meta.helm.sh/release-name": "prometheus-operator-crd","meta.helm.sh/release-namespace": "'"${namespace}"'"},"labels":{"app.kubernetes.io/managed-by": "Helm"}}}' crd
       restartPolicy: Never
   backoffLimit: 4

--- a/helm/prometheus-operator-app/templates/crd-install/crd-job.yaml
+++ b/helm/prometheus-operator-app/templates/crd-install/crd-job.yaml
@@ -38,7 +38,8 @@ spec:
           # in the pod's logs.
           exec 2>&1
 
+          name=$(kubectl get chart --namespace=giantswarm -l app.kubernetes.io/name=prometheus-operator-crd --output=jsonpath="{.items[0].spec.name}")
           namespace=$(kubectl get chart --namespace=giantswarm -l app.kubernetes.io/name=prometheus-operator-crd --output=jsonpath="{.items[0].spec.namespace}")
-          kubectl api-resources --api-group=monitoring.coreos.com -oname|tr '\n' ' '|xargs kubectl patch --record=false -p '{"metadata":{"annotations":{"meta.helm.sh/release-name": "prometheus-operator-crd","meta.helm.sh/release-namespace": "'"${namespace}"'"},"labels":{"app.kubernetes.io/managed-by": "Helm"}}}' crd
+          kubectl api-resources --api-group=monitoring.coreos.com -oname|tr '\n' ' '|xargs kubectl patch --record=false -p '{"metadata":{"annotations":{"meta.helm.sh/release-name": "'"${name}"'","meta.helm.sh/release-namespace": "'"${namespace}"'"},"labels":{"app.kubernetes.io/managed-by": "Helm"}}}' crd
       restartPolicy: Never
   backoffLimit: 4


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/21262

Fixes the crd-install job which patches the crd to inject the correct name and namespace for prometheus-operator-crd.