### PR TITLE
Limit prometheus-operator interactions to its own namespace. Set `releaseNamespace: true`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Limit prometheus-operator interactions to its own namespace. Set `releaseNamespace: true`.
+
 ## [1.2.1] - 2022-05-10
 
 ### Fixed

--- a/helm/prometheus-operator-app/templates/prometheus-operator/deployment.yaml
+++ b/helm/prometheus-operator-app/templates/prometheus-operator/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - --deny-namespaces={{ .Values.prometheusOperator.denyNamespaces | join "," }}
             {{- end }}
             {{- with $.Values.prometheusOperator.namespaces }}
-            {{ $ns := .additional }}
+            {{ $ns := default (list nil) .additional }}
             {{- if .releaseNamespace }}
             {{- $ns = append $ns $namespace }}
             {{- end }}

--- a/helm/prometheus-operator-app/values.yaml
+++ b/helm/prometheus-operator-app/values.yaml
@@ -1471,8 +1471,8 @@ prometheusOperator:
   ## Namespaces to scope the interaction of the Prometheus Operator and the apiserver (allow list).
   ## This is mutually exclusive with denyNamespaces. Setting this to an empty object will disable the configuration
   ##
-  namespaces: {}
-    # releaseNamespace: true
+  namespaces:
+    releaseNamespace: true
     # additional:
     # - kube-system
 


### PR DESCRIPTION
The `releaseNamespace` setting basically set the  `--namespace` setting which limit the interaction of prometheus-operator controllers to certain namespaces ([see upstream](https://github.com/prometheus-operator/prometheus-operator/blob/b475b655a82987eca96e142fe03a1e9c4e51f5f2/cmd/operator/main.go#L228-L253)).

I used this to resolved the following incident [#inc-2022-06-07-otter-ifprd-prometheus-operator-app-operator-servicelevelburnra](https://gigantic.slack.com/archives/C03JKPHUXBM)

```yaml
$ k get deploy prometheus-operator-app-operator -oyaml
...
      containers:
      - args:
        - --alertmanager-instance-namespaces=infra-prometheus-operator-app
        - --prometheus-instance-namespaces=infra-prometheus-operator-app
        - --thanos-ruler-instance-namespaces=infra-prometheus-operator-app
```

This does not affect probe,pod,or service monitors

```yaml
$ k get prometheus prometheus-operator-app-prometheus -oyaml
...
  podMonitorNamespaceSelector:
    matchExpressions:
    - key: podmonblacklisted
      operator: DoesNotExist
  podMonitorSelector:
    matchExpressions:
    - key: podmonblacklisted
      operator: DoesNotExist
  portName: http-web
  probeNamespaceSelector:
    matchExpressions:
    - key: podmonblacklisted
      operator: DoesNotExist
  probeSelector:
    matchExpressions:
    - key: podmonblacklisted
      operator: DoesNotExist
```

I think this is a good setting because it happened multiple times already that prometheus-operator crashed due to high memory usages caused by "customer" massive amount of resources. Here this was due to 130577 secrets in infra-security namespace