### PR TITLE
Add CiliumNetworkPolicy for deployment-label-hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Added `CiliumNetworkPolicy` for the deployment-label-hook.
+
 ## [2.0.2] - 2022-10-31
 
 ### Changed

--- a/helm/prometheus-operator-app/templates/deployment-label-hook/cilium-np.yaml
+++ b/helm/prometheus-operator-app/templates/deployment-label-hook/cilium-np.yaml
@@ -1,7 +1,6 @@
-{{- if not ( .Capabilities.APIVersions.Has "cilium.io/v2" ) }}
----
-kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1
+{{- if .Capabilities.APIVersions.Has "cilium.io/v2" }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
 metadata:
   name: {{ include "prometheus-operator.deployment-label-name" . }}
   namespace: {{ .Release.Namespace | quote }}
@@ -14,26 +13,16 @@ metadata:
     {{- include "kube-prometheus-stack.selectorLabels" . | nindent 4 }}
     role: {{ include "prometheus-operator.deployment-label-selector" . | quote }}
 spec:
-  podSelector:
+  endpointSelector:
     matchLabels:
       app.kubernetes.io/component: {{ include "prometheus-operator.deployment-label-name" . | quote }}
       {{- include "kube-prometheus-stack.selectorLabels" . | nindent 6 }}
-  # allow egress traffic to the Kubernetes API
   egress:
-  - ports:
-    - port: 443
-      protocol: TCP
-    # legacy port kept for compatibility
-    - port: 6443
-      protocol: TCP
-    to:
-    {{- range tuple "10.0.0.0/8" "172.16.0.0/12" "192.168.0.0/16" "100.64.0.0/10" }}
-    - ipBlock:
-        cidr: {{ . }}
-    {{- end }}
-  # deny ingress traffic
-  ingress: []
-  policyTypes:
-  - Egress
-  - Ingress
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "443"
+        - ports:
+            - port: "6443"
 {{- end }}

--- a/helm/prometheus-operator-app/templates/deployment-label-hook/np.yaml
+++ b/helm/prometheus-operator-app/templates/deployment-label-hook/np.yaml
@@ -1,5 +1,3 @@
-{{- if not ( .Capabilities.APIVersions.Has "cilium.io/v2" ) }}
----
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
@@ -36,4 +34,3 @@ spec:
   policyTypes:
   - Egress
   - Ingress
-{{- end }}

--- a/helm/prometheus-operator-app/templates/deployment-label-hook/np.yaml
+++ b/helm/prometheus-operator-app/templates/deployment-label-hook/np.yaml
@@ -1,3 +1,32 @@
+{{- if .Capabilities.APIVersions.Has "cilium.io/v2" }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "prometheus-operator.deployment-label-name" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-7"
+    {{- include "prometheus-operator.deployment-label-annotation" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "prometheus-operator.deployment-label-name" . | quote }}
+    {{- include "kube-prometheus-stack.selectorLabels" . | nindent 4 }}
+    role: {{ include "prometheus-operator.deployment-label-selector" . | quote }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/component: {{ include "prometheus-operator.deployment-label-name" . | quote }}
+      {{- include "kube-prometheus-stack.selectorLabels" . | nindent 6 }}
+  egress:
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "443"
+        - ports:
+            - port: "6443"
+{{- else}}
+---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
@@ -34,3 +63,4 @@ spec:
   policyTypes:
   - Egress
   - Ingress
+{{- end }}


### PR DESCRIPTION
<!--
@team-atlas will be automatically requested for review once
this PR has been submitted.
-->
Now that we use cilium as our CNI, the network policies that rely on ipBlock won't work. We need to add a ciliumnetworkpolicy instead.

Related: https://github.com/giantswarm/external-dns-app/pull/198