### PR TITLE
Enable PSP by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Enable PSP by default.
+
 ## [2.1.0] - 2022-11-24
 
 ### Added

--- a/helm/prometheus-operator-app/values.yaml
+++ b/helm/prometheus-operator-app/values.yaml
@@ -1,5 +1,9 @@
 ---
 prometheus-operator-app:
+  global:
+    rbac:
+      create: true
+      pspEnabled: true
   alertmanager:
     alertmanagerSpec:
       image:


### PR DESCRIPTION
<!--
@team-atlas will be automatically requested for review once
this PR has been submitted.
-->
This PR enabled the PSP by default in the chart, fixing installation issues on new CAPI providers