### PR TITLE
Enable KubeStateMetrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Configure defaults so the app can run successfully in Giant Swarm clusters.
 - Drop unused api-server metrics.
 - Align metric configuration with prometheus-meta-operator scrape config.
+- Enable `kube-state-metrics` from kube-prometheus-stack.
 
 ## [4.0.1] - 2023-03-16
 

--- a/helm/prometheus-operator-app/templates/_helpers.tpl
+++ b/helm/prometheus-operator-app/templates/_helpers.tpl
@@ -14,7 +14,29 @@ heritage: {{ $.Release.Service | quote }}
 {{- end }}
 {{- end }}
 
-{{/* Deploymet label Hook name. */}}
+{{/*
+Generate basic labels
+*/}}
+{{- define "kube-state-metrics.labels" }}
+helm.sh/chart: {{ template "kube-state-metrics.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: metrics
+app.kubernetes.io/part-of: {{ template "kube-state-metrics.name" . }}
+{{- include "kube-state-metrics.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels }}
+{{- end }}
+{{- if .Values.releaseLabel }}
+release: {{ $.Release.Name | quote }}
+heritage: {{ $.Release.Service | quote }}
+{{- end }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | default "atlas" | quote }}
+{{- end }}
+
+{{/* Deployment label Hook name. */}}
 {{- define "prometheus-operator.deployment-label-name" -}}
 {{- printf "%s-%s" ( include "kube-prometheus-stack.name" . ) "hook" | replace "+" "_" | trimSuffix "-" -}}
 {{- end -}}

--- a/helm/prometheus-operator-app/templates/deployment-label-hook/ciliumnetworkpolicy.yaml
+++ b/helm/prometheus-operator-app/templates/deployment-label-hook/ciliumnetworkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "cilium.io/v2" }}
+{{- if or .Values.ciliumNetworkPolicy.enabled (.Capabilities.APIVersions.Has "cilium.io/v2") }}
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -20,9 +20,4 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
-      toPorts:
-        - ports:
-            - port: "443"
-        - ports:
-            - port: "6443"
 {{- end }}

--- a/helm/prometheus-operator-app/templates/kube-state-metrics/ciliumnetworkpolicy.yaml
+++ b/helm/prometheus-operator-app/templates/kube-state-metrics/ciliumnetworkpolicy.yaml
@@ -1,0 +1,16 @@
+{{- if or .Values.ciliumNetworkPolicy.enabled (.Capabilities.APIVersions.Has "cilium.io/v2") }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ template "kube-state-metrics.fullname" . }}
+  namespace: {{ template "kube-state-metrics.namespace" . }}
+  labels:
+    {{- include "kube-state-metrics.labels" . | indent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      {{- include "kube-state-metrics.selectorLabels" . | indent 6 }}
+  egress:
+    - toEntities:
+        - kube-apiserver
+{{ end }}

--- a/helm/prometheus-operator-app/values.schema.json
+++ b/helm/prometheus-operator-app/values.schema.json
@@ -2,6 +2,14 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "ciliumNetworkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "global": {
             "type": "object",
             "properties": {

--- a/helm/prometheus-operator-app/values.schema.json
+++ b/helm/prometheus-operator-app/values.schema.json
@@ -145,13 +145,37 @@
                                 }
                             }
                         },
+                        "metricLabelsAllowlist": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
                         "networkPolicy": {
                             "type": "object",
                             "properties": {
                                 "egress": {
                                     "type": "array",
                                     "items": {
-                                        "type": "object"
+                                        "type": "object",
+                                        "properties": {
+                                            "to": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "ipBlock": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "cidr": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
                                     }
                                 },
                                 "enabled": {
@@ -160,8 +184,40 @@
                                 "ingress": {
                                     "type": "array",
                                     "items": {
-                                        "type": "object"
+                                        "type": "object",
+                                        "properties": {
+                                            "ports": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "port": {
+                                                            "type": "integer"
+                                                        },
+                                                        "protocol": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
                                     }
+                                }
+                            }
+                        },
+                        "podAnnotations": {
+                            "type": "object",
+                            "properties": {
+                                "cluster-autoscaler.kubernetes.io/safe-to-evict": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "podSecurityPolicy": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
                                 }
                             }
                         },
@@ -182,7 +238,7 @@
                                                     "regex": {
                                                         "type": "string"
                                                     },
-                                                    "source_labels": {
+                                                    "sourceLabels": {
                                                         "type": "array",
                                                         "items": {
                                                             "type": "string"
@@ -192,6 +248,44 @@
                                             }
                                         }
                                     }
+                                }
+                            }
+                        },
+                        "prometheusScrape": {
+                            "type": "boolean"
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "limits": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cpu": {
+                                            "type": "string"
+                                        },
+                                        "memory": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "requests": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cpu": {
+                                            "type": "string"
+                                        },
+                                        "memory": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "selfMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
                                 }
                             }
                         },
@@ -297,7 +391,7 @@
                                             "regex": {
                                                 "type": "string"
                                             },
-                                            "source_labels": {
+                                            "sourceLabels": {
                                                 "type": "array",
                                                 "items": {
                                                     "type": "string"
@@ -385,7 +479,7 @@
                                             "regex": {
                                                 "type": "string"
                                             },
-                                            "source_labels": {
+                                            "sourceLabels": {
                                                 "type": "array",
                                                 "items": {
                                                     "type": "string"
@@ -423,44 +517,49 @@
                 "kubelet": {
                     "type": "object",
                     "properties": {
-                        "cadvisorMetricRelabelings": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "action": {
-                                        "type": "string"
-                                    },
-                                    "regex": {
-                                        "type": "string"
-                                    },
-                                    "sourceLabels": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        },
                         "enabled": {
                             "type": "boolean"
                         },
-                        "metricRelabelings": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "action": {
-                                        "type": "string"
-                                    },
-                                    "regex": {
-                                        "type": "string"
-                                    },
-                                    "source_labels": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "string"
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "cAdvisorMetricRelabelings": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "action": {
+                                                "type": "string"
+                                            },
+                                            "regex": {
+                                                "type": "string"
+                                            },
+                                            "sourceLabels": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "action": {
+                                                "type": "string"
+                                            },
+                                            "regex": {
+                                                "type": "string"
+                                            },
+                                            "sourceLabels": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string"
+                                                }
+                                            }
                                         }
                                     }
                                 }

--- a/helm/prometheus-operator-app/values.schema.json
+++ b/helm/prometheus-operator-app/values.schema.json
@@ -227,6 +227,9 @@
                                 "monitor": {
                                     "type": "object",
                                     "properties": {
+                                        "enabled": {
+                                            "type": "boolean"
+                                        },
                                         "metricRelabelings": {
                                             "type": "array",
                                             "items": {

--- a/helm/prometheus-operator-app/values.yaml
+++ b/helm/prometheus-operator-app/values.yaml
@@ -190,6 +190,12 @@ prometheus-operator-app:
       - ports:
         - port: 8080
           protocol: TCP
+        - port: 8081
+          protocol: TCP
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+    podSecurityPolicy:
+      enabled: true
     prometheus:
       monitor:
         metricRelabelings:
@@ -246,10 +252,6 @@ prometheus-operator-app:
           targetLabel: nodepool
           replacement: ${1}
           action: replace
-    podAnnotations:
-      cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
-    podSecurityPolicy:
-      enabled: true
     # Remove prometheus.io/scrape annotation
     prometheusScrape: false
     ## We set resources so VPA can do its thing

--- a/helm/prometheus-operator-app/values.yaml
+++ b/helm/prometheus-operator-app/values.yaml
@@ -199,6 +199,7 @@ prometheus-operator-app:
       enabled: true
     prometheus:
       monitor:
+        enabled: true
         metricRelabelings:
         # GS addition to reduce cardinality
         # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
@@ -254,12 +255,6 @@ prometheus-operator-app:
           replacement: ${1}
           action: replace
     # Remove prometheus.io/scrape annotation
-    prometheus:
-      monitor:
-        enabled: true
-        relabelings:
-        - action: labeldrop
-          regex: uid|container_id
     prometheusScrape: false
     ## We set resources so VPA can do its thing
     resources:
@@ -272,7 +267,7 @@ prometheus-operator-app:
     selfMonitor:
       enabled: true
     verticalPodAutoscaler:
-      enabled: true  
+      enabled: true
   nodeExporter:
     enabled: false
   prometheus-node-exporter:

--- a/helm/prometheus-operator-app/values.yaml
+++ b/helm/prometheus-operator-app/values.yaml
@@ -165,18 +165,31 @@ prometheus-operator-app:
         regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
         action: drop
   kubeStateMetrics:
-    enabled: false
+    enabled: true
   kube-state-metrics:
     image:
       repository: giantswarm/kube-state-metrics
-    verticalPodAutoscaler:
-      enabled: true
+    metricLabelsAllowlist:
+    - daemonsets=[giantswarm.io/monitoring_basic_sli, giantswarm.io/service-type, app.kubernetes.io/name, application.giantswarm.io/team]
+    - deployments=[giantswarm.io/monitoring_basic_sli, giantswarm.io/service-type, app.kubernetes.io/name, application.giantswarm.io/team]
+    - nodes=[ip, giantswarm.io/machine-pool, giantswarm.io/machine-deployment, topology.kubernetes.io/region, topology.kubernetes.io/zone]
+    - statefulsets=[giantswarm.io/monitoring_basic_sli, giantswarm.io/service-type, app.kubernetes.io/name, application.giantswarm.io/team]
     networkPolicy:
       enabled: true
       egress:
-      - {}
+      - to:
+        - ipBlock:
+            cidr: 10.0.0.0/8
+        - ipBlock:
+            cidr: 172.16.0.0/12
+        - ipBlock:
+            cidr: 192.168.0.0/16
+        - ipBlock:
+            cidr: 100.64.0.0/10
       ingress:
-      - {}
+      - ports:
+        - port: 8080
+          protocol: TCP
     prometheus:
       monitor:
         metricRelabelings:
@@ -233,6 +246,24 @@ prometheus-operator-app:
           targetLabel: nodepool
           replacement: ${1}
           action: replace
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+    podSecurityPolicy:
+      enabled: true
+    # Remove prometheus.io/scrape annotation
+    prometheusScrape: false
+    ## We set resources so VPA can do its thing
+    resources:
+      requests:
+        cpu: 200m
+        memory: 200Mi
+      limits:
+        cpu: 200m
+        memory: 200Mi
+    selfMonitor:
+      enabled: true
+    verticalPodAutoscaler:
+      enabled: true  
   nodeExporter:
     enabled: false
   prometheus-node-exporter:

--- a/helm/prometheus-operator-app/values.yaml
+++ b/helm/prometheus-operator-app/values.yaml
@@ -167,6 +167,7 @@ prometheus-operator-app:
   kubeStateMetrics:
     enabled: true
   kube-state-metrics:
+    # TODO Add Cilium Network Policy https://github.com/giantswarm/kube-state-metrics-app/pull/183
     image:
       repository: giantswarm/kube-state-metrics
     metricLabelsAllowlist:
@@ -253,6 +254,12 @@ prometheus-operator-app:
           replacement: ${1}
           action: replace
     # Remove prometheus.io/scrape annotation
+    prometheus:
+      monitor:
+        enabled: true
+        relabelings:
+        - action: labeldrop
+          regex: uid|container_id
     prometheusScrape: false
     ## We set resources so VPA can do its thing
     resources:

--- a/helm/prometheus-operator-app/values.yaml
+++ b/helm/prometheus-operator-app/values.yaml
@@ -213,6 +213,9 @@ prometheus-operator-app:
         - action: labeldrop
           regex: uid|image_id|container_id
         # GS addition for dashboards
+        - targetLabel: app
+          replacement: kube-state-metrics
+          action: replace
         - sourceLabels: [deployment]
           targetLabel: workload_type
           replacement: deployment

--- a/helm/prometheus-operator-app/values.yaml
+++ b/helm/prometheus-operator-app/values.yaml
@@ -3,6 +3,10 @@ global:
   rbac:
     create: true
     pspEnabled: true
+
+ciliumNetworkPolicy:
+  enabled: false
+
 prometheus-operator-app:
   alertmanager:
     alertmanagerSpec:
@@ -167,7 +171,6 @@ prometheus-operator-app:
   kubeStateMetrics:
     enabled: true
   kube-state-metrics:
-    # TODO Add Cilium Network Policy https://github.com/giantswarm/kube-state-metrics-app/pull/183
     image:
       repository: giantswarm/kube-state-metrics
     metricLabelsAllowlist:

--- a/helm/prometheus-operator-app/values.yaml
+++ b/helm/prometheus-operator-app/values.yaml
@@ -25,6 +25,10 @@ prometheus-operator-app:
       selector:
         k8s-app: coredns
     serviceMonitor:
+      relabelings:
+      # Add app label.
+      - targetLabel: app
+        replacement: coredns
       metricRelabelings:
       # GS addition to reduce cardinality
       - action: drop
@@ -75,6 +79,10 @@ prometheus-operator-app:
   kubelet:
     enabled: true
     serviceMonitor:
+      cAdvisorRelabelings:
+      # Add app label.
+      - targetLabel: app
+        replacement: cadvisor
       cAdvisorMetricRelabelings:
       # Drop less useful container CPU metrics.
       - sourceLabels: [__name__]
@@ -107,6 +115,10 @@ prometheus-operator-app:
       - sourceLabels: [__name__]
         regex: container_(blkio_device_usage_total|network_transmit_errors_total|network_receive_errors_total|memory_failures_total|memory_max_usage_bytes|memory_failcnt)
         action: drop
+      relabelings:
+      # Add app label.
+      - targetLabel: app
+        replacement: kubelet
       metricRelabelings:
       # GS addition to reduce cardinality
       # drop unused rest client metrics
@@ -142,8 +154,18 @@ prometheus-operator-app:
         action: drop
   kubeEtcd:
     enabled: true
+    serviceMonitor:
+      relabelings:
+      # Add app label.
+      - targetLabel: app
+        replacement: etcd
   kubeProxy:
     enabled: true
+    serviceMonitor:
+      relabelings:
+      # Add app label.
+      - targetLabel: app
+        replacement: kube-proxy
   kubeScheduler:
     enabled: true
     service:
@@ -203,6 +225,10 @@ prometheus-operator-app:
     prometheus:
       monitor:
         enabled: true
+        relabelings:
+        # Add app label.
+        - targetLabel: app
+          replacement: kube-state-metrics
         metricRelabelings:
         # GS addition to reduce cardinality
         # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
@@ -213,9 +239,6 @@ prometheus-operator-app:
         - action: labeldrop
           regex: uid|image_id|container_id
         # GS addition for dashboards
-        - targetLabel: app
-          replacement: kube-state-metrics
-          action: replace
         - sourceLabels: [deployment]
           targetLabel: workload_type
           replacement: deployment


### PR DESCRIPTION
Enables kube-state-metrics so we can deprecate https://github.com/giantswarm/kube-state-metrics-app


This will ensure a smoother upgrade process for KSM

```diff
2c2
< # Source: kube-state-metrics/templates/networkpolicy.yaml
---
> # Source: prometheus-operator-app/charts/prometheus-operator-app/charts/kube-state-metrics/templates/networkpolicy.yaml
6,7d5
<   name: release-name-kube-state-metrics
<   namespace: default
9c7
<     helm.sh/chart: kube-state-metrics-0.1.0
---
>     helm.sh/chart: kube-state-metrics-5.0.0
15,16c13,15
<     app.kubernetes.io/version: "2.6.0"
<     "giantswarm.io/service-type": "managed"
---
>     app.kubernetes.io/version: "2.8.1"
>     release: "release-name"
>     heritage: "Helm"
17a17,18
>   name: release-name-kube-state-metrics
>   namespace: default
18a20,34
>   ## Deny all egress by default
>   egress:
>     - to:
>       - ipBlock:
>           cidr: 10.0.0.0/8
>       - ipBlock:
>           cidr: 172.16.0.0/12
>       - ipBlock:
>           cidr: 192.168.0.0/16
>       - ipBlock:
>           cidr: 100.64.0.0/10
>   ingress:
>     - ports:
>       - port: 8080
>         protocol: TCP
26,39d41
<   ingress:
<   - ports:
<     - port: 8080
<       protocol: TCP
<   egress:
<   - to:
<     - ipBlock:
<         cidr: 10.0.0.0/8
<     - ipBlock:
<         cidr: 172.16.0.0/12
<     - ipBlock:
<         cidr: 192.168.0.0/16
<     - ipBlock:
<         cidr: 100.64.0.0/10
41c43
< # Source: kube-state-metrics/templates/podsecuritypolicy.yaml
---
> # Source: prometheus-operator-app/charts/prometheus-operator-app/charts/kube-state-metrics/templates/podsecuritypolicy.yaml
47c49
<     helm.sh/chart: kube-state-metrics-0.1.0
---
>     helm.sh/chart: kube-state-metrics-5.0.0
53,54c55,57
<     app.kubernetes.io/version: "2.6.0"
<     "giantswarm.io/service-type": "managed"
---
>     app.kubernetes.io/version: "2.8.1"
>     release: "release-name"
>     heritage: "Helm"
81c84
< # Source: kube-state-metrics/templates/serviceaccount.yaml
---
> # Source: prometheus-operator-app/charts/prometheus-operator-app/charts/kube-state-metrics/templates/serviceaccount.yaml
86c89
<     helm.sh/chart: kube-state-metrics-0.1.0
---
>     helm.sh/chart: kube-state-metrics-5.0.0
92,93c95,97
<     app.kubernetes.io/version: "2.6.0"
<     "giantswarm.io/service-type": "managed"
---
>     app.kubernetes.io/version: "2.8.1"
>     release: "release-name"
>     heritage: "Helm"
98d101
<   []
100c103
< # Source: kube-state-metrics/templates/psp-clusterrole.yaml
---
> # Source: prometheus-operator-app/charts/prometheus-operator-app/charts/kube-state-metrics/templates/psp-clusterrole.yaml
105c108
<     helm.sh/chart: kube-state-metrics-0.1.0
---
>     helm.sh/chart: kube-state-metrics-5.0.0
111,112c114,116
<     app.kubernetes.io/version: "2.6.0"
<     "giantswarm.io/service-type": "managed"
---
>     app.kubernetes.io/version: "2.8.1"
>     release: "release-name"
>     heritage: "Helm"
122c126
< # Source: kube-state-metrics/templates/role.yaml
---
> # Source: prometheus-operator-app/charts/prometheus-operator-app/charts/kube-state-metrics/templates/role.yaml
127c131
<     helm.sh/chart: kube-state-metrics-0.1.0
---
>     helm.sh/chart: kube-state-metrics-5.0.0
133,134c137,139
<     app.kubernetes.io/version: "2.6.0"
<     "giantswarm.io/service-type": "managed"
---
>     app.kubernetes.io/version: "2.8.1"
>     release: "release-name"
>     heritage: "Helm"
183a189,193
> - apiGroups: ["coordination.k8s.io"]
>   resources:
>   - leases
>   verbs: ["list", "watch"]
> 
274c284
< # Source: kube-state-metrics/templates/clusterrolebinding.yaml
---
> # Source: prometheus-operator-app/charts/prometheus-operator-app/charts/kube-state-metrics/templates/clusterrolebinding.yaml
279c289
<     helm.sh/chart: kube-state-metrics-0.1.0
---
>     helm.sh/chart: kube-state-metrics-5.0.0
285,286c295,297
<     app.kubernetes.io/version: "2.6.0"
<     "giantswarm.io/service-type": "managed"
---
>     app.kubernetes.io/version: "2.8.1"
>     release: "release-name"
>     heritage: "Helm"
298c309
< # Source: kube-state-metrics/templates/psp-clusterrolebinding.yaml
---
> # Source: prometheus-operator-app/charts/prometheus-operator-app/charts/kube-state-metrics/templates/psp-clusterrolebinding.yaml
303c314
<     helm.sh/chart: kube-state-metrics-0.1.0
---
>     helm.sh/chart: kube-state-metrics-5.0.0
309,310c320,322
<     app.kubernetes.io/version: "2.6.0"
<     "giantswarm.io/service-type": "managed"
---
>     app.kubernetes.io/version: "2.8.1"
>     release: "release-name"
>     heritage: "Helm"
322c334
< # Source: kube-state-metrics/templates/service.yaml
---
> # Source: prometheus-operator-app/charts/prometheus-operator-app/charts/kube-state-metrics/templates/service.yaml
329c341
<     helm.sh/chart: kube-state-metrics-0.1.0
---
>     helm.sh/chart: kube-state-metrics-5.0.0
335,336c347,349
<     app.kubernetes.io/version: "2.6.0"
<     "giantswarm.io/service-type": "managed"
---
>     app.kubernetes.io/version: "2.8.1"
>     release: "release-name"
>     heritage: "Helm"
338d350
<     giantswarm.io/monitoring: "true"
340d351
<     prometheus.io/scrape: 'true'
348a360,364
>   - name: "metrics"
>     protocol: TCP
>     port: 8081
>     targetPort: 8081
>   
353c369
< # Source: kube-state-metrics/templates/deployment.yaml
---
> # Source: prometheus-operator-app/charts/prometheus-operator-app/charts/kube-state-metrics/templates/deployment.yaml
360c376
<     helm.sh/chart: kube-state-metrics-0.1.0
---
>     helm.sh/chart: kube-state-metrics-5.0.0
366,367c382,384
<     app.kubernetes.io/version: "2.6.0"
<     "giantswarm.io/service-type": "managed"
---
>     app.kubernetes.io/version: "2.8.1"
>     release: "release-name"
>     heritage: "Helm"
378c395
<         helm.sh/chart: kube-state-metrics-0.1.0
---
>         helm.sh/chart: kube-state-metrics-5.0.0
384,385c401,403
<         app.kubernetes.io/version: "2.6.0"
<         "giantswarm.io/service-type": "managed"
---
>         app.kubernetes.io/version: "2.8.1"
>         release: "release-name"
>         heritage: "Helm"
396d413
<       priorityClassName: system-cluster-critical
401c418
<         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
---
>         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
404c421
<         image: "docker.io/giantswarm/kube-state-metrics:v2.6.0"
---
>         image: docker.io/giantswarm/kube-state-metrics:v2.8.1
407a425,426
>         - containerPort: 8081
>           name: "metrics"
420a440,442
>           limits:
>             cpu: 200m
>             memory: 200Mi
422,423c444,500
<             cpu: 500m
<             memory: 500Mi
---
>             cpu: 200m
>             memory: 200Mi
> ---
> # Source: prometheus-operator-app/charts/prometheus-operator-app/charts/kube-state-metrics/templates/servicemonitor.yaml
> apiVersion: monitoring.coreos.com/v1
> kind: ServiceMonitor
> metadata:
>   name: release-name-kube-state-metrics
>   namespace: default
>   labels:    
>     helm.sh/chart: kube-state-metrics-5.0.0
>     app.kubernetes.io/managed-by: Helm
>     app.kubernetes.io/component: metrics
>     app.kubernetes.io/part-of: kube-state-metrics
>     app.kubernetes.io/name: kube-state-metrics
>     app.kubernetes.io/instance: release-name
>     app.kubernetes.io/version: "2.8.1"
>     release: "release-name"
>     heritage: "Helm"
>     application.giantswarm.io/team: "atlas"
> spec:
>   jobLabel: app.kubernetes.io/name  
>   selector:
>     matchLabels:      
>       app.kubernetes.io/name: kube-state-metrics
>       app.kubernetes.io/instance: release-name
>   endpoints:
>     - port: http
>       honorLabels: true
>     - port: metrics
>       honorLabels: true
> ---
> # Source: prometheus-operator-app/charts/prometheus-operator-app/charts/kube-state-metrics/templates/verticalpodautoscaler.yaml
> apiVersion: autoscaling.k8s.io/v1
> kind: VerticalPodAutoscaler
> metadata:
>   name: release-name-kube-state-metrics
>   namespace: default
>   labels:    
>     helm.sh/chart: kube-state-metrics-5.0.0
>     app.kubernetes.io/managed-by: Helm
>     app.kubernetes.io/component: metrics
>     app.kubernetes.io/part-of: kube-state-metrics
>     app.kubernetes.io/name: kube-state-metrics
>     app.kubernetes.io/instance: release-name
>     app.kubernetes.io/version: "2.8.1"
>     release: "release-name"
>     heritage: "Helm"
>     application.giantswarm.io/team: "atlas"
> spec:
>   resourcePolicy:
>     containerPolicies:
>     - containerName: kube-state-metrics
>   targetRef:
>     apiVersion: apps/v1
>     kind: Deployment
>     name:  release-name-kube-state-metrics

```
