### PR TITLE
Fix KSM image repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix kube-state-metrics image repository.
+
 ## [4.0.0] - 2023-03-13
 
 ### Changed

--- a/helm/prometheus-operator-app/values.yaml
+++ b/helm/prometheus-operator-app/values.yaml
@@ -41,6 +41,8 @@ prometheus-operator-app:
   kubeStateMetrics:
     enabled: false
   kube-state-metrics:
+    image:
+      repository: giantswarm/kube-state-metrics
     verticalPodAutoscaler:
       enabled: true
     networkPolicy:


### PR DESCRIPTION
Fixes a customer issue

For context, in 3.0.0, global.imageRegistry was broken in the ksm subchart but this was fixed in the latest one so instead.

That means that in 3.0.0, the KSM image was `registry.k8s.io/kube-state-metrics/kube-state-metric` but when the global registry was fixed, the image then became `docker.io/kube-state-metrics/kube-state-metrics:v2.8.1`.

This was planned to be fixed by https://github.com/giantswarm/prometheus-operator-app/pull/244.

This issue is all the more proving that we should use KSM in this chart instead of our own app, because this is used by customers and not tested on our side