### PR TITLE
Fix KSM cilium netpol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix kube-state-metrics cilium network policy selector.
+
 ## [4.2.0] - 2023-04-06
 
 ### Added

--- a/helm/prometheus-operator-app/templates/_helpers.tpl
+++ b/helm/prometheus-operator-app/templates/_helpers.tpl
@@ -14,28 +14,6 @@ heritage: {{ $.Release.Service | quote }}
 {{- end }}
 {{- end }}
 
-{{/*
-Generate basic labels
-*/}}
-{{- define "kube-state-metrics.labels" }}
-helm.sh/chart: {{ template "kube-state-metrics.chart" . }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/component: metrics
-app.kubernetes.io/part-of: {{ template "kube-state-metrics.name" . }}
-{{- include "kube-state-metrics.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-{{- if .Values.customLabels }}
-{{ toYaml .Values.customLabels }}
-{{- end }}
-{{- if .Values.releaseLabel }}
-release: {{ $.Release.Name | quote }}
-heritage: {{ $.Release.Service | quote }}
-{{- end }}
-application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | default "atlas" | quote }}
-{{- end }}
-
 {{/* Deployment label Hook name. */}}
 {{- define "prometheus-operator.deployment-label-name" -}}
 {{- printf "%s-%s" ( include "kube-prometheus-stack.name" . ) "hook" | replace "+" "_" | trimSuffix "-" -}}
@@ -61,4 +39,50 @@ app.kubernetes.io/instance: "{{ template "kube-prometheus-stack.name" . }}"
 {{- define "kube-prometheus-stack.networkPolicySelector" }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 release: {{ $.Release.Name | quote }}
+{{- end }}
+
+
+{{/* kube-state-metrics section */}}
+{{- define "kube-state-metrics.name" -}}
+{{- default "kube-state-metrics" .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kube-state-metrics.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "kube-state-metrics" .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate basic labels
+*/}}
+{{- define "kube-state-metrics.labels" }}
+helm.sh/chart: {{ template "kube-state-metrics.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: metrics
+app.kubernetes.io/part-of: {{ template "kube-state-metrics.name" . }}
+{{- include "kube-state-metrics.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels }}
+{{- end }}
+{{- if .Values.releaseLabel }}
+release: {{ $.Release.Name | quote }}
+heritage: {{ $.Release.Service | quote }}
+{{- end }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | default "atlas" | quote }}
 {{- end }}


### PR DESCRIPTION
Fixes KSM netpol name and selector


From:

```yaml
# Source: prometheus-operator-app/templates/kube-state-metrics/ciliumnetworkpolicy.yaml
apiVersion: cilium.io/v2
kind: CiliumNetworkPolicy
metadata:
  name: release-name-prometheus-operator-app
  namespace: default
  labels:    
    helm.sh/chart: prometheus-operator-app-4.2.0
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: metrics
    app.kubernetes.io/part-of: prometheus-operator-app
    app.kubernetes.io/name: prometheus-operator-app
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.63.0"
    application.giantswarm.io/team: "atlas"
spec:
  endpointSelector:
    matchLabels:      
      app.kubernetes.io/name: prometheus-operator-app
      app.kubernetes.io/instance: release-name
  egress:
    - toEntities:
        - kube-apiserver
```

to 

```yaml
# Source: prometheus-operator-app/templates/kube-state-metrics/ciliumnetworkpolicy.yaml
apiVersion: cilium.io/v2
kind: CiliumNetworkPolicy
metadata:
  name: release-name-kube-state-metrics
  namespace: default
  labels:    
    helm.sh/chart: prometheus-operator-app-4.2.0
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: metrics
    app.kubernetes.io/part-of: kube-state-metrics
    app.kubernetes.io/name: kube-state-metrics
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.63.0"
    application.giantswarm.io/team: "atlas"
spec:
  endpointSelector:
    matchLabels:      
      app.kubernetes.io/name: kube-state-metrics
      app.kubernetes.io/instance: release-name
  egress:
    - toEntities:
        - kube-apiserver
```

Diff is in the name and selector