### PR TITLE
Remove 'container_id' from drop labels in KSM metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove `container_id` from drop labels in KSM metrics.
+
 ## [5.0.2] - 2023-05-30
 
 ### Changed

--- a/helm/prometheus-operator-app/values.yaml
+++ b/helm/prometheus-operator-app/values.yaml
@@ -287,7 +287,7 @@ prometheus-operator-app:
           action: drop
         # drop uid, image_id and container_id labels
         - action: labeldrop
-          regex: uid|image_id|container_id
+          regex: uid|image_id
         # GS addition for dashboards
         - sourceLabels: [deployment]
           targetLabel: workload_type

--- a/helm/prometheus-operator-app/values.yaml
+++ b/helm/prometheus-operator-app/values.yaml
@@ -285,7 +285,7 @@ prometheus-operator-app:
         - sourceLabels: [__name__]
           regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas|.+_metadata_resource_version|verticalpodautoscaler_annotations|verticalpodautoscaler_labels)
           action: drop
-        # drop uid, image_id and container_id labels
+        # drop uid and image_id labels
         - action: labeldrop
           regex: uid|image_id
         # GS addition for dashboards


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/27099

Fix KSM duplicate samples which raise PrometheusFailsToCommunicateWithRemoteStorageAPI alert