### PR TITLE
Remove uid (pod_id) from drop labels in KSM metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove `uid` (pod_id) from drop labels in KSM metrics.
+
 ## [5.0.4] - 2023-06-02
 
 ### Changed

--- a/helm/prometheus-operator-app/values.yaml
+++ b/helm/prometheus-operator-app/values.yaml
@@ -285,9 +285,9 @@ prometheus-operator-app:
         - sourceLabels: [__name__]
           regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas|.+_metadata_resource_version|verticalpodautoscaler_annotations|verticalpodautoscaler_labels)
           action: drop
-        # drop uid and image_id labels
+        # drop image_id label
         - action: labeldrop
-          regex: uid|image_id
+          regex: image_id
         # GS addition for dashboards
         - sourceLabels: [deployment]
           targetLabel: workload_type


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/27181

