### PR TITLE
Revert previous upgrade of kube-prometheus-stack

### DIFF
--- a/helm/prometheus-operator-app/Chart.yaml
+++ b/helm/prometheus-operator-app/Chart.yaml
@@ -14,6 +14,6 @@ annotations:
   application.giantswarm.io/team: atlas
 dependencies:
   - name: kube-prometheus-stack
-    version: 46.8.0
+    version: 46.6.0
     repository: https://prometheus-community.github.io/helm-charts
     alias: prometheus-operator-app


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/27228

We downgrade `kube-prometheus-stack` to `46.6.0` since we find a fix to vpa removing (>= 46.7.0)