### PR TITLE
Move Cluster Autoscaler safe-to-evict annotation to be pod Annotation not a deployment one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Move `prometheus-operator` `cluster-autoscaler safe-to-evict` annotation to `podAnnotations` rather than the deployment annotation
+
 ## [5.0.5] - 2023-06-09
 
 ### Fixed

--- a/helm/prometheus-operator-app/values.yaml
+++ b/helm/prometheus-operator-app/values.yaml
@@ -381,7 +381,7 @@ prometheus-operator-app:
         image:
           repository: giantswarm/ingress-nginx-kube-webhook-certgen
     alertmanagerDefaultBaseImage: giantswarm/alertmanager
-    annotations:
+    podAnnotations:
       cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     image:
       repository: giantswarm/prometheus-operator


### PR DESCRIPTION
<!--
@team-atlas will be automatically requested for review once
this PR has been submitted.
-->
Towards https://github.com/giantswarm/vodafone/issues/617
