### PR TITLE
remove KSM VPA minAllowed, set high limits/requests ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Add `app.kubernetes.io/component` and `app.kubernetes.io/instance` to the list of allowed labels.
 
+### Changed
+
+- Replaced Kube-State-Metrics Vertical-Pod-Autoscaler minAllowed resources with high limits/requests ratio to prevent throttling and yet spare resources on clusters any size.
+
 ## [5.0.7] - 2023-07-07
 
 ### Fixed

--- a/helm/prometheus-operator-app/values.yaml
+++ b/helm/prometheus-operator-app/values.yaml
@@ -328,15 +328,12 @@ prometheus-operator-app:
         cpu: 200m
         memory: 200Mi
       limits:
-        cpu: 200m
+        cpu: 2000m
         memory: 200Mi
     selfMonitor:
       enabled: true
     verticalPodAutoscaler:
       enabled: true
-      minAllowed:
-        cpu: 200m
-        memory: 200Mi
   nodeExporter:
     enabled: false
   prometheus-node-exporter:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/27934

Replaced Kube-State-Metrics Vertical-Pod-Autoscaler minAllowed resources with high limits/requests ratio to prevent throttling and yet spare resources on clusters any size.