### PR TITLE
Update metricLabelsAllowlist for daemonsets, deployments, and statefulsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add labels to Deployment, DaemonSet, StatefulSet metrics: `app.kubernetes.io/version`, `helm.toolkit.fluxcd.io/name`, `helm.toolkit.fluxcd.io/namespace`
+
 ## [20.1.0] - 2026-03-04
 
 ### Changed

--- a/helm/kube-prometheus-stack/values.yaml
+++ b/helm/kube-prometheus-stack/values.yaml
@@ -242,11 +242,11 @@ kube-prometheus-stack:
     metricLabelsAllowlist:
     - cronjobs=[application.giantswarm.io/team, app.kubernetes.io/name]
     - jobs=[application.giantswarm.io/team, app.kubernetes.io/name]
-    - daemonsets=[application.giantswarm.io/team, app.kubernetes.io/name, app.kubernetes.io/component, app.kubernetes.io/instance, giantswarm.io/service-type]
-    - deployments=[application.giantswarm.io/team, app.kubernetes.io/name, app.kubernetes.io/component, app.kubernetes.io/instance, giantswarm.io/service-type]
+    - daemonsets=[application.giantswarm.io/team, app.kubernetes.io/name, app.kubernetes.io/component, app.kubernetes.io/instance, app.kubernetes.io/version, giantswarm.io/service-type, helm.toolkit.fluxcd.io/name, helm.toolkit.fluxcd.io/namespace]
+    - deployments=[application.giantswarm.io/team, app.kubernetes.io/name, app.kubernetes.io/component, app.kubernetes.io/instance, app.kubernetes.io/version, giantswarm.io/service-type, helm.toolkit.fluxcd.io/name, helm.toolkit.fluxcd.io/namespace]
     - nodes=[giantswarm.io/machine-pool, giantswarm.io/machine-deployment, ip, node.kubernetes.io/instance-type, topology.kubernetes.io/region, topology.kubernetes.io/zone]
     - pods=[application.giantswarm.io/team, app.kubernetes.io/name, app.kubernetes.io/component, app.kubernetes.io/instance, giantswarm.io/service-type]
-    - statefulsets=[application.giantswarm.io/team, app.kubernetes.io/name, app.kubernetes.io/component, app.kubernetes.io/instance, giantswarm.io/service-type]
+    - statefulsets=[application.giantswarm.io/team, app.kubernetes.io/name, app.kubernetes.io/component, app.kubernetes.io/instance, app.kubernetes.io/version, giantswarm.io/service-type, helm.toolkit.fluxcd.io/name, helm.toolkit.fluxcd.io/namespace]
     # Available collectors for kube-state-metrics.
     # By default, all available resources are enabled, comment out to disable.
     collectors:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/4243

We add additional labels to Deployment, DaemonSet, StatefulSet metrics:

- `app.kubernetes.io/version`
- `helm.toolkit.fluxcd.io/name`
- `helm.toolkit.fluxcd.io/namespace`
