### PR TITLE
fix(ksm): move metricRelabelings ownership to observability-bundle

### DIFF
--- a/helm/kube-prometheus-stack/values.yaml
+++ b/helm/kube-prometheus-stack/values.yaml
@@ -316,58 +316,6 @@ kube-prometheus-stack:
         # Add node label.
         - sourceLabels: [__meta_kubernetes_pod_node_name]
           targetLabel: node
-        metricRelabelings:
-        # GS addition to reduce cardinality
-        # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
-        - sourceLabels: [__name__]
-          regex: kube_(.+_annotations|secret_type|pod_status_qos_class|pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas|.+_metadata_resource_version)
-          action: drop
-        # drop image_id label
-        - action: labeldrop
-          regex: image_id
-        # GS addition for dashboards
-        - sourceLabels: [label_topology_kubernetes_io_region]
-          targetLabel: region
-          replacement: ${1}
-          action: replace
-        - sourceLabels: [label_topology_kubernetes_io_zone]
-          targetLabel: zone
-          replacement: ${1}
-          action: replace
-        - action: labeldrop
-          regex: label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone
-        # Override with label for AWS clusters if exists.
-        - sourceLabels: [label_giantswarm_io_machine_deployment]
-          targetLabel: nodepool
-          replacement: ${1}
-          action: replace
-        # Override with label for Azure clusters if exists.
-        - sourceLabels: [label_giantswarm_io_machine_pool]
-          targetLabel: nodepool
-          replacement: ${1}
-          action: replace
-
-        # CAPI monitoring specific BEGIN
-        # (see kube-state-metrics rules in https://github.com/giantswarm/observability-bundle/tree/main/helm/observability-bundle/ksm-configurations)
-
-        - action: replace
-          sourceLabels:
-            - __name__
-            - cluster_name
-          regex: "^capi_.+;(.+)"
-          replacement: "${1}"
-          targetLabel: cluster_id
-        # Use the `name` label as cluster name if the above fails
-        - action: replace
-          sourceLabels:
-            - __name__
-            - cluster_name
-            - name
-          regex: "^capi_.+;;(.+)"
-          replacement: "${1}"
-          targetLabel: cluster_id
-
-        # CAPI monitoring specific END
 
     # Remove prometheus.io/scrape annotation
     prometheusScrape: false


### PR DESCRIPTION
## Summary

- Removes the KSM `metricRelabelings` block from kube-prometheus-stack defaults
- Rules moved: cardinality drops, topology labels, nodepool labels, CAPI `cluster_id` mapping
- These are now owned by `observability-bundle` which also adds the new `cluster_type` labeling (see giantswarm/observability-bundle#...)
- Safe to remove: all MCs use obs-bundle, so no rules are lost

## Dependencies

- giantswarm/observability-bundle#386 (obs-bundle must be updated to consume this value)
- giantswarm/cluster#826 (must pass managementCluster via defaultValues)

Fixes: https://github.com/giantswarm/giantswarm/issues/35079