### PR TITLE
fix: fix ABS override_app_version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ workflows:
           chart: "kube-prometheus-stack"
           explicit_allow_chart_name_mismatch: true
           ct_config: ".circleci/ct-config.yaml"
+          override_app_version: false
           filters:
             # Trigger the job also on git tag.
             tags:
@@ -28,6 +29,7 @@ workflows:
           chart: "kube-prometheus-stack"
           explicit_allow_chart_name_mismatch: true
           ct_config: ".circleci/ct-config.yaml"
+          override_app_version: false
           filters:
             # Trigger the job also on git tag.
             tags:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Add `app.circleci.com/circle-project-reponame` label to the KSM Pods labels allowed list.
 
+### Changed
+
+- Fix ABS config to not override AppVersion in Chart.yaml
+
 ## [21.0.0] - 2026-05-22
 
 ### Changed


### PR DESCRIPTION
In recent versions, ABS and architect orb changed the default behaviour for overriding the AppVersion in Chart.yaml when building and pushing charts. Now the default is to override it.
This does not work for this chart, since we use an upstream image with a different version than the chart itself.