### PR TITLE
chore: remove `ct_config` from push-to-app-catalog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ workflows:
           app_catalog_test: "default-test-catalog"
           chart: "kube-prometheus-stack"
           explicit_allow_chart_name_mismatch: true
-          ct_config: ".circleci/ct-config.yaml"
           override_app_version: false
           filters:
             # Trigger the job also on git tag.
@@ -28,7 +27,6 @@ workflows:
           app_catalog_test: "giantswarm-test-catalog"
           chart: "kube-prometheus-stack"
           explicit_allow_chart_name_mismatch: true
-          ct_config: ".circleci/ct-config.yaml"
           override_app_version: false
           filters:
             # Trigger the job also on git tag.


### PR DESCRIPTION
`ct_config` has been **ignored by architect-orb since v9.0.0 (when the `helm-lint` step it controlled was removed)** — passing it currently does nothing.

It is removed in the upcoming **architect-orb v10.0.0**. Because CircleCI fails config compilation on unknown job arguments, any repo still passing it will break the moment Renovate bumps the orb to v10. Merging this beforehand makes that bump a no-op for you.

No behaviour change: the parameter is already a no-op today.

Part of giantswarm/roadmap#4066